### PR TITLE
fix(chat_history):

### DIFF
--- a/src/agents/a2a/dvd_executor.py
+++ b/src/agents/a2a/dvd_executor.py
@@ -94,7 +94,10 @@ class DocumentQaAgentExecutor:
                 temperature=execution["temperature"],
                 user_query=execution["user_query"],
                 scenario_id=execution["scenario_id"],
+                # chat_id is passed for read-only history context; A2A tasks
+                # must leave no trace in ChatStorage.
                 chat_id=execution["chat_id"],
+                persist_history=False,
             ):
                 event = self._pipeline_item_to_event(task_id, context_id, item)
                 if event is None:

--- a/src/agents/a2a/executor.py
+++ b/src/agents/a2a/executor.py
@@ -142,6 +142,8 @@ class RestrictionAgentExecutor:
                 user_query=execution["user_query"],
                 scenario_id=execution["scenario_id"],
                 request_id=task_id,
+                # A2A tasks must leave no trace in ChatStorage.
+                persist_history=False,
             ):
                 event = self._pipeline_item_to_event(task_id, context_id, item)
                 if event is None:

--- a/src/agents/a2a/provision_executor.py
+++ b/src/agents/a2a/provision_executor.py
@@ -101,6 +101,8 @@ class ProvisionAgentExecutor:
                 user_query=execution["user_query"],
                 scenario_id=execution["scenario_id"],
                 request_id=task_id,
+                # A2A tasks must leave no trace in ChatStorage.
+                persist_history=False,
             ):
                 event = self._pipeline_item_to_event(task_id, context_id, item)
                 if event is None:

--- a/src/agents/api_clients/chat_storage_client/chat_storage_client.py
+++ b/src/agents/api_clients/chat_storage_client/chat_storage_client.py
@@ -40,8 +40,8 @@ class ChatStorageApiClient:
         """
 
         return MessageAdded(
-            chat_id=message["message_id"],
-            message_id=message["chat_id"],
+            chat_id=message["chat_id"],
+            message_id=message["message_id"],
             message_type=creation_type,
         )
 

--- a/src/agents/services/base_llm_service.py
+++ b/src/agents/services/base_llm_service.py
@@ -290,6 +290,7 @@ class BaseLlmService(BaseLlmClient):
     def build_llm_history(
         messages: list[dict],
         max_messages: int = 10,
+        current_user_query: str | None = None,
     ) -> list[dict]:
         """
         Convert chat storage messages to a compact Ollama-compatible list.
@@ -299,6 +300,10 @@ class BaseLlmService(BaseLlmClient):
         Args:
             messages: Raw message dicts from ChatHistory.messages.
             max_messages: Maximum number of messages to keep (most recent).
+            current_user_query: The query being processed right now. If the stored
+                history ends with this exact user message (it is persisted before the
+                pipeline runs, so a reconnect fetches it back), that trailing copy is
+                dropped — services append the current query to the LLM context themselves.
         Returns:
             list[dict]: Messages in {"role": ..., "content": ...} format.
         """
@@ -324,5 +329,13 @@ class BaseLlmService(BaseLlmClient):
             combined = "\n".join(texts).strip()
             if combined:
                 result.append({"role": role, "content": combined})
+
+        if (
+            current_user_query
+            and result
+            and result[-1]["role"] == "user"
+            and result[-1]["content"] == current_user_query.strip()
+        ):
+            result.pop()
 
         return result[-max_messages:]

--- a/src/agents/services/dvd_rag_service.py
+++ b/src/agents/services/dvd_rag_service.py
@@ -84,6 +84,7 @@ class DvdRagService(BaseLlmService):
         scenario_id: int | None = None,
         chat_id: str | None = None,
         request_id: str | None = None,
+        persist_history: bool = True,
     ) -> AsyncGenerator[dict[str, Any], None]:
         collected: dict[str, Any] = {
             "final_answer": "",
@@ -120,7 +121,9 @@ class DvdRagService(BaseLlmService):
             # No chat_id supplied → create a new chat tagged with scenario_id. The
             # project_id is resolved from scenario_id; if that lookup fails we warn the
             # client, drop the project filter, and keep going (the chat is still created).
-            if not chat_id:
+            # A2A runs pass persist_history=False: no chat is created and nothing is
+            # written to ChatStorage (history stays read-only).
+            if not chat_id and persist_history:
                 project_id: int | None = None
                 if scenario_id is not None:
                     try:
@@ -171,9 +174,28 @@ class DvdRagService(BaseLlmService):
         if original_chat_id:
             try:
                 chat_info = await self.get_chat_messages(token, original_chat_id)
-                history = self.build_llm_history(chat_info.messages)
+                history = self.build_llm_history(
+                    chat_info.messages, current_user_query=user_query
+                )
             except Exception as exc:
                 logger.warning(f"DVD QA: failed to fetch chat history: {exc}")
+
+        # A follow-up question in an existing chat is persisted here — create_chat
+        # stores only the first one. Runs after the history fetch so the current
+        # question doesn't also enter the LLM context from storage, and is skipped
+        # on reconnect (the original run already stored it). Chat storage failures
+        # must not break the stream.
+        if persist_history and not is_reconnect and original_chat_id:
+            try:
+                await self.add_single_message(
+                    token,
+                    original_chat_id,
+                    RoleEnum.USER,
+                    user_query,
+                    scenario_id=scenario_id,
+                )
+            except Exception as exc:
+                logger.warning(f"DVD QA: failed to persist user question: {exc}")
 
         async for event in self._run_qa_loop(
             dvd_mcp_client,
@@ -188,7 +210,7 @@ class DvdRagService(BaseLlmService):
 
         # Persist only when this run actually produced the answer — never on a reconnect
         # that merely replayed an already-completed pipeline (avoids duplicate messages).
-        if collected.get("newly_completed"):
+        if persist_history and collected.get("newly_completed"):
             self._schedule_persist_answer(token, chat_id, collected, scenario_id)
 
     # ------------------------------------------------------------------

--- a/src/agents/services/provsion_service.py
+++ b/src/agents/services/provsion_service.py
@@ -128,6 +128,7 @@ class ProvisionService(BaseLlmService):
         scenario_id: int,
         chat_id: str | None = None,
         request_id: str | None = None,
+        persist_history: bool = True,
     ) -> AsyncGenerator:
         token_ref: list[str] = [
             idu_mcp_client.mcp_client.transport.auth.token.get_secret_value()
@@ -145,6 +146,7 @@ class ProvisionService(BaseLlmService):
             chat_id=chat_id,
             request_id=request_id,
             token_ref=token_ref,
+            persist_history=persist_history,
         ):
             chat_id = self._chat_id_from_storage_event(item) or chat_id
             if item.get("type") == "tool_call":
@@ -173,12 +175,14 @@ class ProvisionService(BaseLlmService):
 
         if text_buffer:
             self._flush_text_buffer_to_parts(text_buffer, message_parts)
-        self._schedule_add_message_parts_to_chat(
-            token_ref[0],
-            chat_id,
-            message_parts,
-            scenario_id=scenario_id,
-        )
+        # A2A runs pass persist_history=False — no ChatStorage writes at all.
+        if persist_history:
+            self._schedule_add_message_parts_to_chat(
+                token_ref[0],
+                chat_id,
+                message_parts,
+                scenario_id=scenario_id,
+            )
 
     # ------------------------------------------------------------------
     # Inner pipeline
@@ -195,6 +199,7 @@ class ProvisionService(BaseLlmService):
         token_ref: list[str],
         chat_id: str | None = None,
         request_id: str | None = None,
+        persist_history: bool = True,
     ) -> AsyncGenerator:
         is_reconnect = request_id is not None and await self.state_store.exists(
             request_id
@@ -214,7 +219,9 @@ class ProvisionService(BaseLlmService):
         if not is_reconnect:
             yield self._buf(request_id, self._pipeline_started_event(request_id))
 
-            if not chat_id:
+            # A2A runs pass persist_history=False: no chat is created and nothing
+            # is written to ChatStorage (history stays read-only).
+            if not chat_id and persist_history:
                 chat_result: list[tuple[str, str]] = []
                 try:
                     async for event in self._retryable_step(
@@ -255,9 +262,28 @@ class ProvisionService(BaseLlmService):
         if original_chat_id:
             try:
                 chat_info = await self.get_chat_messages(token_ref[0], original_chat_id)
-                llm_history = self.build_llm_history(chat_info.messages)
+                llm_history = self.build_llm_history(
+                    chat_info.messages, current_user_query=user_query
+                )
             except Exception as exc:
                 logger.warning(f"Failed to fetch chat history: {exc}")
+
+        # A follow-up question in an existing chat is persisted here — create_chat
+        # stores only the first one. Runs after the history fetch so the current
+        # question doesn't also enter the LLM context from storage, and is skipped
+        # on reconnect (the original run already stored it). Chat storage failures
+        # must not break the stream.
+        if persist_history and not is_reconnect and original_chat_id:
+            try:
+                await self.add_single_message(
+                    token_ref[0],
+                    original_chat_id,
+                    RoleEnum.USER,
+                    user_query,
+                    scenario_id=scenario_id,
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to persist user question: {exc}")
 
         checkpoint = await self.state_store.get_checkpoint(request_id)
 

--- a/src/agents/services/restriction_parser_service.py
+++ b/src/agents/services/restriction_parser_service.py
@@ -78,6 +78,7 @@ class RestrictionParserService(BaseLlmService):
         scenario_id: int,
         chat_id: str | None = None,
         request_id: str | None = None,
+        persist_history: bool = True,
     ) -> AsyncGenerator:
         # Mutable container so the inner pipeline can update the token on
         # refresh and the outer generator sees the latest value.
@@ -98,6 +99,7 @@ class RestrictionParserService(BaseLlmService):
             chat_id=chat_id,
             request_id=request_id,
             token_ref=token_ref,
+            persist_history=persist_history,
         ):
             chat_id = self._chat_id_from_storage_event(item) or chat_id
             if item.get("type") == "tool_call":
@@ -129,12 +131,14 @@ class RestrictionParserService(BaseLlmService):
         if text_buffer:
             self._flush_text_buffer_to_parts(text_buffer, message_parts)
         # Use token_ref[0]: may have been refreshed during pipeline execution.
-        self._schedule_add_message_parts_to_chat(
-            token_ref[0],
-            chat_id,
-            message_parts,
-            scenario_id=scenario_id,
-        )
+        # A2A runs pass persist_history=False — no ChatStorage writes at all.
+        if persist_history:
+            self._schedule_add_message_parts_to_chat(
+                token_ref[0],
+                chat_id,
+                message_parts,
+                scenario_id=scenario_id,
+            )
 
     async def _run_restriction_execution_pipline(
         self,
@@ -146,6 +150,7 @@ class RestrictionParserService(BaseLlmService):
         token_ref: list[str],
         chat_id: str | None = None,
         request_id: str | None = None,
+        persist_history: bool = True,
     ) -> AsyncGenerator:
         is_reconnect = request_id is not None and await self.state_store.exists(
             request_id
@@ -170,7 +175,9 @@ class RestrictionParserService(BaseLlmService):
         if not is_reconnect:
             yield self._buf(request_id, self._pipeline_started_event(request_id))
 
-            if not chat_id:
+            # A2A runs pass persist_history=False: no chat is created and nothing
+            # is written to ChatStorage (history stays read-only).
+            if not chat_id and persist_history:
                 logger.info("No chat id provided, creating a new chat.")
                 chat_result: list[tuple[str, str]] = []
                 try:
@@ -212,12 +219,31 @@ class RestrictionParserService(BaseLlmService):
         if original_chat_id:
             try:
                 chat_info = await self.get_chat_messages(token_ref[0], original_chat_id)
-                llm_history = self.build_llm_history(chat_info.messages)
+                llm_history = self.build_llm_history(
+                    chat_info.messages, current_user_query=user_query
+                )
                 logger.info(f"Loaded {len(llm_history)} messages from chat history")
             except Exception as exc:
                 logger.warning(
                     f"Failed to fetch chat history, proceeding without it: {exc}"
                 )
+
+        # A follow-up question in an existing chat is persisted here — create_chat
+        # stores only the first one. Runs after the history fetch so the current
+        # question doesn't also enter the LLM context from storage, and is skipped
+        # on reconnect (the original run already stored it). Chat storage failures
+        # must not break the stream.
+        if persist_history and not is_reconnect and original_chat_id:
+            try:
+                await self.add_single_message(
+                    token_ref[0],
+                    original_chat_id,
+                    RoleEnum.USER,
+                    user_query,
+                    scenario_id=scenario_id,
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to persist user question: {exc}")
 
         checkpoint = await self.state_store.get_checkpoint(request_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,5 +67,6 @@ def service(monkeypatch, fake_llm, fake_urban, state_store):
     svc = DvdRagService("http://ollama", Mock(), fake_urban, state_store)
     svc.create_chat = AsyncMock(return_value=("chat-xyz", "Тестовый чат"))
     svc.get_chat_messages = AsyncMock(return_value=SimpleNamespace(messages=[]))
+    svc.add_single_message = AsyncMock()
     svc._schedule_persist_answer = Mock()
     return svc

--- a/tests/unit/test_a2a_no_history_persistence.py
+++ b/tests/unit/test_a2a_no_history_persistence.py
@@ -1,0 +1,60 @@
+"""A2A runs must leave no trace in ChatStorage: every A2A executor calls its
+pipeline with persist_history=False (the DVD executor is covered in test_dvd_a2a.py)."""
+
+from __future__ import annotations
+
+from src.agents.a2a.executor import RestrictionAgentExecutor
+from src.agents.a2a.provision_executor import ProvisionAgentExecutor
+from src.agents.a2a.task_store import A2ATaskStore
+
+_PARAMS = {
+    "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "запрос"}],
+        "metadata": {"scenario_id": 772},
+    }
+}
+
+_DONE_CHUNK = {"type": "chunk", "content": {"text": "ответ", "done": True}}
+
+
+class FakeRestrictionService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def run_restriction_execution_pipline(self, **kwargs):
+        self.calls.append(kwargs)
+        yield _DONE_CHUNK
+
+
+class FakeProvisionService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def run_provision_pipeline(self, **kwargs):
+        self.calls.append(kwargs)
+        yield _DONE_CHUNK
+
+
+async def test_restriction_executor_disables_history_persistence():
+    service = FakeRestrictionService()
+    ex = RestrictionAgentExecutor(service, A2ATaskStore())
+
+    async for _ in ex.stream(_PARAMS, mcp_client=object()):
+        pass
+
+    (call,) = service.calls
+    assert call["persist_history"] is False
+
+
+async def test_provision_executor_disables_history_persistence():
+    service = FakeProvisionService()
+    ex = ProvisionAgentExecutor(service, A2ATaskStore())
+
+    async for _ in ex.stream(
+        _PARAMS, idu_mcp_client=object(), effects_mcp_client=object()
+    ):
+        pass
+
+    (call,) = service.calls
+    assert call["persist_history"] is False

--- a/tests/unit/test_build_llm_history.py
+++ b/tests/unit/test_build_llm_history.py
@@ -1,0 +1,56 @@
+"""Unit tests for BaseLlmService.build_llm_history — history compaction and the
+trailing-current-question dedup (the current question is persisted before the pipeline
+runs, so a reconnect fetches it back as the last history message)."""
+
+from __future__ import annotations
+
+from src.agents.services.base_llm_service import BaseLlmService
+
+
+def _msg(role: str, content: str) -> dict:
+    return {"role": role, "content": content}
+
+
+def test_extracts_text_and_skips_other_roles():
+    messages = [
+        _msg("system", "internal"),
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+    ]
+    assert BaseLlmService.build_llm_history(messages) == [
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+    ]
+
+
+def test_drops_trailing_copy_of_current_question():
+    messages = [
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+        _msg("user", "Q2"),
+    ]
+    history = BaseLlmService.build_llm_history(messages, current_user_query="Q2")
+    assert history == [_msg("user", "Q1"), _msg("assistant", "A1")]
+
+
+def test_keeps_matching_question_when_not_trailing():
+    # The same text earlier in the chat (followed by an answer) must stay.
+    messages = [
+        _msg("user", "Q1"),
+        _msg("assistant", "A1"),
+    ]
+    history = BaseLlmService.build_llm_history(messages, current_user_query="Q1")
+    assert history == [_msg("user", "Q1"), _msg("assistant", "A1")]
+
+
+def test_no_dedup_without_current_query():
+    messages = [_msg("user", "Q1")]
+    assert BaseLlmService.build_llm_history(messages) == [_msg("user", "Q1")]
+
+
+def test_dedup_applies_before_max_messages_slice():
+    messages = [_msg("user", f"Q{i}") for i in range(5)] + [_msg("user", "current")]
+    history = BaseLlmService.build_llm_history(
+        messages, max_messages=3, current_user_query="current"
+    )
+    assert history == [_msg("user", "Q2"), _msg("user", "Q3"), _msg("user", "Q4")]

--- a/tests/unit/test_dvd_a2a.py
+++ b/tests/unit/test_dvd_a2a.py
@@ -15,8 +15,10 @@ class FakeRag:
 
     def __init__(self, events: list[dict]) -> None:
         self._events = events
+        self.calls: list[dict] = []
 
     async def run_document_qa_pipeline(self, **kwargs):
+        self.calls.append(kwargs)
         for event in self._events:
             yield event
 
@@ -182,6 +184,29 @@ async def test_execute_returns_completed_task_with_artifact():
     )
     assert task["status"]["state"] == "completed"
     assert task["artifacts"]
+
+
+async def test_stream_disables_history_persistence():
+    # A2A runs must leave no trace in ChatStorage: chat_id is forwarded only for
+    # read-only history context, persist_history is always False.
+    rag = FakeRag(
+        [{"type": "chunk", "content": {"text": "A", "done": False, "iteration": 1}}]
+    )
+    ex = DocumentQaAgentExecutor(rag, A2ATaskStore())
+    params = {
+        "message": {
+            "role": "user",
+            "parts": [{"type": "text", "text": "q"}],
+            "metadata": {"chat_id": "c9"},
+        }
+    }
+
+    async for _ in ex.stream(params, dvd_mcp_client=object(), token="t"):
+        pass
+
+    (call,) = rag.calls
+    assert call["persist_history"] is False
+    assert call["chat_id"] == "c9"
 
 
 async def test_stream_failure_emits_failed_status():

--- a/tests/unit/test_dvd_rag_service.py
+++ b/tests/unit/test_dvd_rag_service.py
@@ -312,6 +312,114 @@ class TestReconnect:
 
 
 # ---------------------------------------------------------------------------
+# User-question persistence (follow-up questions in an existing chat)
+# ---------------------------------------------------------------------------
+class TestUserQuestionPersistence:
+    async def test_follow_up_question_saved_to_existing_chat(
+        self, service, fake_llm, fake_mcp
+    ):
+        from src.agents.api_clients.chat_storage_client.entities import RoleEnum
+
+        fake_llm.json_responses = [plan_json(), verdict_json(satisfied=True)]
+        fake_llm.answer_texts = ["Ответ"]
+
+        await _run(service, fake_mcp, chat_id="chat-1")
+
+        service.add_single_message.assert_awaited_once()
+        token, chat_id, role, text = service.add_single_message.await_args.args
+        assert chat_id == "chat-1"
+        assert role == RoleEnum.USER
+        assert text == "вопрос"
+
+    async def test_new_chat_does_not_double_save_first_question(
+        self, service, fake_llm, fake_mcp
+    ):
+        # create_chat itself stores the first question — the pipeline must not add a copy
+        fake_llm.json_responses = [plan_json(), verdict_json(satisfied=True)]
+        fake_llm.answer_texts = ["Ответ"]
+
+        await _run(service, fake_mcp, chat_id=None)
+
+        service.create_chat.assert_awaited_once()
+        service.add_single_message.assert_not_awaited()
+
+    async def test_reconnect_does_not_resave_question(
+        self, service, fake_llm, fake_mcp, state_store
+    ):
+        rid = "44444444-4444-4444-4444-444444444444"
+        await state_store.create(
+            rid,
+            chat_id="chat-1",
+            user_query="вопрос",
+            scenario_id=None,
+            model="m",
+            temperature=0.0,
+        )
+        await state_store.save_checkpoint(
+            rid,
+            "qa_progress",
+            {
+                "completed_iterations": 1,
+                "tool_calls": [],
+                "accepted": True,
+                "final_answer": "Готовый ответ",
+                "final_iteration": 1,
+                "prev_critique": None,
+                "prev_query": None,
+            },
+        )
+
+        await _run(service, fake_mcp, chat_id="chat-1", request_id=rid)
+
+        service.add_single_message.assert_not_awaited()
+
+    async def test_persist_failure_does_not_break_stream(
+        self, service, fake_llm, fake_mcp
+    ):
+        service.add_single_message.side_effect = RuntimeError("chat storage down")
+        fake_llm.json_responses = [plan_json(), verdict_json(satisfied=True)]
+        fake_llm.answer_texts = ["Ответ"]
+
+        events = await _run(service, fake_mcp, chat_id="chat-1")
+
+        assert answer_text(events) == "Ответ"
+        assert final_chunk(events)["done"] is True
+
+
+# ---------------------------------------------------------------------------
+# persist_history=False (A2A runs): no ChatStorage writes at all
+# ---------------------------------------------------------------------------
+class TestPersistHistoryDisabled:
+    async def test_no_writes_with_existing_chat_but_history_still_read(
+        self, service, fake_llm, fake_mcp
+    ):
+        fake_llm.json_responses = [plan_json(), verdict_json(satisfied=True)]
+        fake_llm.answer_texts = ["Ответ"]
+
+        events = await _run(service, fake_mcp, chat_id="chat-1", persist_history=False)
+
+        service.create_chat.assert_not_awaited()
+        service.add_single_message.assert_not_awaited()
+        service._schedule_persist_answer.assert_not_called()
+        # chat_id is still used for read-only LLM context
+        service.get_chat_messages.assert_awaited_once()
+        assert answer_text(events) == "Ответ"
+
+    async def test_no_chat_created_without_chat_id(self, service, fake_llm, fake_mcp):
+        fake_llm.json_responses = [plan_json(), verdict_json(satisfied=True)]
+        fake_llm.answer_texts = ["Ответ"]
+
+        events = await _run(service, fake_mcp, chat_id=None, persist_history=False)
+
+        service.create_chat.assert_not_awaited()
+        service.add_single_message.assert_not_awaited()
+        service._schedule_persist_answer.assert_not_called()
+        # no chat_created service_event is emitted
+        assert not events_of_type(events, "service_event")
+        assert answer_text(events) == "Ответ"
+
+
+# ---------------------------------------------------------------------------
 # Persistence (parts building)
 # ---------------------------------------------------------------------------
 async def test_persist_answer_builds_toolcall_and_text_parts(


### PR DESCRIPTION
- persist follow-up user questions in restriction, provision and document-QA pipelines (previously only the first question of a new chat was saved)
- drop the trailing copy of the current question from LLM history on reconnect (build_llm_history current_user_query)
- added persist_history flag to all three pipelines; A2A executors pass False so A2A runs make no ChatStorage writes (chat_id kept for read-only history context)
- fixed swapped chat_id/message_id in ChatStorageApiClient._message_created
- tests: user-question persistence, persist_history=False guards, build_llm_history dedup, A2A executor flags