### PR TITLE
feat(orchestrator): add orchestrator agent — single entry point routi…

### DIFF
--- a/src/agents/dependencies/dependencies.py
+++ b/src/agents/dependencies/dependencies.py
@@ -13,6 +13,7 @@ from src.agents.services.dvd_a2a_service import DocumentQaA2AService
 from src.agents.services.dvd_rag_service import DvdRagService
 from src.agents.services.normgraph_a2a_service import NormGraphA2AService
 from src.agents.services.normgraph_rag_service import NormGraphRagService
+from src.agents.services.orchestrator_service import OrchestratorService
 from src.agents.services.pipeline_state import PipelineStateStore
 from src.agents.services.provision_a2a_service import ProvisionA2AService
 from src.agents.services.provsion_service import ProvisionService
@@ -151,6 +152,51 @@ async def get_normgraph_mcp_client() -> NormGraphMcpClient:
             "NORM_GRAPH_MCP_SERVER is not configured — set it to enable the /norms agent"
         )
     return NormGraphMcpClient(Client(mcp_url), mcp_url=mcp_url)
+
+
+async def get_optional_dvd_mcp_client() -> DvdMcpClient | None:
+    """
+    Function returns a DvdMcpClient when DVD_MCP_SERVER is configured, else None.
+
+    Used by the orchestrator: the documents agent is simply excluded from the
+    planner catalogue when the URL is unset, so the endpoint must not fail.
+    Returns:
+        DvdMcpClient | None: Client for the IDU_DVD MCP server or None.
+    """
+
+    mcp_url: str | None = app_deps["app_config"].DVD_MCP_URL
+    if not mcp_url:
+        return None
+    return DvdMcpClient(Client(mcp_url), mcp_url=mcp_url)
+
+
+async def get_optional_normgraph_mcp_client() -> NormGraphMcpClient | None:
+    """
+    Function returns a NormGraphMcpClient when NORM_GRAPH_MCP_SERVER is configured, else None.
+
+    Used by the orchestrator: the norms agent is simply excluded from the
+    planner catalogue when the URL is unset, so the endpoint must not fail.
+    Returns:
+        NormGraphMcpClient | None: Client for the NormGraph MCP server or None.
+    """
+
+    mcp_url: str | None = app_deps["app_config"].NORM_GRAPH_MCP_URL
+    if not mcp_url:
+        return None
+    return NormGraphMcpClient(Client(mcp_url), mcp_url=mcp_url)
+
+
+def get_orchestrator_service() -> OrchestratorService:
+    """
+    Function returns initialized OrchestratorService object from dependencies.
+    Returns:
+        OrchestratorService: OrchestratorService instance.
+    """
+
+    service: OrchestratorService = app_deps["orchestrator_service"]
+    if not isinstance(service, OrchestratorService):
+        raise TypeError(f"Expected OrchestratorService, got {type(service)}")
+    return service
 
 
 def get_normgraph_rag_service() -> NormGraphRagService:

--- a/src/agents/dependencies/init_dependencies.py
+++ b/src/agents/dependencies/init_dependencies.py
@@ -17,6 +17,7 @@ from src.agents.services.dvd_a2a_service import DocumentQaA2AService
 from src.agents.services.dvd_rag_service import DvdRagService
 from src.agents.services.normgraph_a2a_service import NormGraphA2AService
 from src.agents.services.normgraph_rag_service import NormGraphRagService
+from src.agents.services.orchestrator_service import OrchestratorService
 from src.agents.services.pipeline_state import PipelineStateStore
 from src.agents.services.provision_a2a_service import ProvisionA2AService
 from src.agents.services.provsion_service import ProvisionService
@@ -38,6 +39,7 @@ def init_dependencies() -> dict[
     | ProvisionService
     | DvdRagService
     | NormGraphRagService
+    | OrchestratorService
     | A2AService
     | ProvisionA2AService
     | DocumentQaA2AService
@@ -81,6 +83,17 @@ def init_dependencies() -> dict[
         urban_api_client,
         pipeline_state_store,
     )
+    orchestrator_service = OrchestratorService(
+        app_config.OLLAMA_URL,
+        chat_storage_client,
+        urban_api_client,
+        pipeline_state_store,
+        restriction_parser_service,
+        provision_service,
+        dvd_rag_service,
+        normgraph_rag_service,
+        app_config,
+    )
     return {
         "app_config": app_config,
         "system_service": SystemService(logs_path, app_config),
@@ -93,6 +106,7 @@ def init_dependencies() -> dict[
         "provision_service": provision_service,
         "dvd_rag_service": dvd_rag_service,
         "normgraph_rag_service": normgraph_rag_service,
+        "orchestrator_service": orchestrator_service,
         "a2a_service": A2AService(restriction_parser_service),
         "provision_a2a_service": ProvisionA2AService(provision_service),
         "dvd_a2a_service": DocumentQaA2AService(dvd_rag_service),

--- a/src/agents/dto/orchestrator_request_dto.py
+++ b/src/agents/dto/orchestrator_request_dto.py
@@ -1,0 +1,47 @@
+from pydantic import Field
+
+from src.agents.dto.llm_request_dto import SimpleRequestDTO
+
+
+class OrchestratorRequestDTO(SimpleRequestDTO):
+    """
+    DTO for the orchestrator endpoint — the single entry point for all agents.
+
+    The orchestrator plans which agents should handle the request and runs them
+    sequentially; scenario_id gates the availability of the restriction and
+    provision agents.
+    Attributes:
+        scenario_id (int | None): Scenario ID from Urban API. Required for
+            restriction/provision steps; without it the planner only routes to
+            the documents/norms agents.
+        chat_id (str | None): Chat Storage UUID for history continuity.
+        request_id (str | None): Existing pipeline request ID — pass it to
+            replay the buffered events of an interrupted stream.
+    """
+
+    scenario_id: int | None = Field(
+        default=None,
+        examples=[772],
+        description=(
+            "Scenario ID from Urban API (optional). Required for the restriction "
+            "and provision agents; when chat_id is not provided, a new chat is "
+            "created in ChatStorage tagged with this scenario_id."
+        ),
+    )
+    chat_id: str | None = Field(
+        min_length=36,
+        max_length=36,
+        default=None,
+        examples=["550e8400-e29b-41d4-a716-446655440000"],
+        description="Chat ID from Chat Storage for history continuity",
+    )
+    request_id: str | None = Field(
+        min_length=36,
+        max_length=36,
+        default=None,
+        examples=["550e8400-e29b-41d4-a716-446655440001"],
+        description=(
+            "Existing pipeline request ID (from the pipeline_started event). "
+            "Pass it to reconnect to an interrupted stream and replay its events."
+        ),
+    )

--- a/src/agents/main.py
+++ b/src/agents/main.py
@@ -19,6 +19,7 @@ from src.agents.routers.dvd_a2a_controller import dvd_a2a_router
 from src.agents.routers.dvd_controller import dvd_router
 from src.agents.routers.norms_a2a_controller import norms_a2a_router
 from src.agents.routers.norms_controller import norms_router
+from src.agents.routers.orchestrator_controller import orchestrator_router
 from src.agents.routers.provision_a2a_controller import provision_a2a_router
 from src.agents.routers.provision_controller import provision_router
 from src.agents.routers.restriction_parser_controller import restriction_router
@@ -73,6 +74,7 @@ app.include_router(restriction_router)
 app.include_router(provision_router)
 app.include_router(dvd_router)
 app.include_router(norms_router)
+app.include_router(orchestrator_router)
 app.include_router(token_refresh_router)
 app.include_router(restriction_a2a_router)
 app.include_router(provision_a2a_router)

--- a/src/agents/routers/orchestrator_controller.py
+++ b/src/agents/routers/orchestrator_controller.py
@@ -1,0 +1,71 @@
+from collections.abc import AsyncIterable
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.sse import EventSourceResponse
+
+from src.agents.common.auth.auth import verify_bearer_token
+from src.agents.common.executors.sse_executors import stream_with_error_handling
+from src.agents.dependencies.dependencies import (
+    get_effects_mcp_client,
+    get_idu_mcp_client,
+    get_optional_dvd_mcp_client,
+    get_optional_normgraph_mcp_client,
+    get_orchestrator_service,
+)
+from src.agents.dto.orchestrator_request_dto import OrchestratorRequestDTO
+from src.agents.mcp_clients.dvd_mcp_client import DvdMcpClient
+from src.agents.mcp_clients.effects_mcp_client import EffectsMcpClient
+from src.agents.mcp_clients.idu_mcp_client import IduMcpClient
+from src.agents.mcp_clients.normgraph_mcp_client import NormGraphMcpClient
+from src.agents.schema.orchestrator_response import OrchestratorResponse
+from src.agents.services.orchestrator_service import OrchestratorService
+
+orchestrator_router = APIRouter(prefix="/orchestrator", tags=["orchestrator"])
+
+
+@orchestrator_router.get(
+    "/route/stream",
+    response_class=EventSourceResponse,
+    summary="Route a user request across gMART agents and stream aggregated results",
+)
+async def stream_orchestration(
+    request: Request,
+    user_request: Annotated[OrchestratorRequestDTO, Depends(OrchestratorRequestDTO)],
+    token: str = Depends(verify_bearer_token),
+    idu_mcp_client: IduMcpClient = Depends(get_idu_mcp_client),
+    effects_mcp_client: EffectsMcpClient = Depends(get_effects_mcp_client),
+    dvd_mcp_client: DvdMcpClient | None = Depends(get_optional_dvd_mcp_client),
+    normgraph_mcp_client: NormGraphMcpClient | None = Depends(
+        get_optional_normgraph_mcp_client
+    ),
+    orchestrator_service: OrchestratorService = Depends(get_orchestrator_service),
+) -> AsyncIterable[OrchestratorResponse]:
+    """
+    Single entry point for all gMART agents.
+
+    An LLM planner maps the request onto a sequential plan of steps over the
+    restriction / provision / documents / norms agents; each step's events are
+    forwarded inside ``step_event`` envelopes and the run ends with a structured
+    ``orchestrator_final`` per-step summary. When no agent fits, a single
+    ``clarification`` event with a question for the user is emitted instead.
+    """
+
+    async for chunk in stream_with_error_handling(
+        orchestrator_service.run_orchestration_pipeline,
+        request,
+        orchestrator_service,
+        user_request.model,
+        rerun=False,
+        idu_mcp_client=idu_mcp_client,
+        effects_mcp_client=effects_mcp_client,
+        dvd_mcp_client=dvd_mcp_client,
+        normgraph_mcp_client=normgraph_mcp_client,
+        token=token,
+        user_query=user_request.request,
+        scenario_id=user_request.scenario_id,
+        chat_id=user_request.chat_id,
+        request_id=user_request.request_id,
+        temperature=user_request.temperature,
+    ):
+        yield OrchestratorResponse(**chunk)

--- a/src/agents/schema/orchestrator_response.py
+++ b/src/agents/schema/orchestrator_response.py
@@ -1,0 +1,129 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from src.agents.common.exceptions.sse_exceptions import SseBaseError
+from src.agents.schema.dvd_response import (
+    DvdTextResponse,
+    PipelineStartedContent,
+    ServiceEvent,
+    WarningContent,
+)
+
+StepStatus = Literal["completed", "failed", "suspended"]
+
+
+class OrchestratorStatusResponse(BaseModel):
+    """Status update for an orchestrator-level stage."""
+
+    status: Literal["planning"]
+    text: str
+
+
+class PlanStepInfo(BaseModel):
+    """One planned agent step as announced in the ``plan`` event."""
+
+    step: int
+    agent: str
+    agent_title: str
+    task: str
+
+
+class PlanContent(BaseModel):
+    """The full orchestration plan announced before execution starts."""
+
+    steps: list[PlanStepInfo]
+
+
+class StepStartedContent(BaseModel):
+    """
+    Emitted when a step's sub-pipeline starts.
+    Attributes:
+        step (int): 1-based step number.
+        agent (str): Agent key from the catalogue.
+        step_request_id (str): The sub-pipeline's own request ID — use it with
+            ``POST /pipelines/{step_request_id}/token`` to refresh an expired token.
+        task (str): The sub-task the agent was given.
+    """
+
+    step: int
+    agent: str
+    step_request_id: str
+    task: str
+
+
+class StepEventContent(BaseModel):
+    """
+    An event of a sub-agent forwarded verbatim inside the orchestrator envelope.
+    Attributes:
+        step (int): 1-based step number the event belongs to.
+        agent (str): Agent key from the catalogue.
+        event (dict): The original sub-agent SSE event (``{"type", "content"}``)
+            in the agent's native format.
+    """
+
+    step: int
+    agent: str
+    event: dict[str, Any]
+
+
+class StepFinishedContent(BaseModel):
+    """Terminal event of a single step with its text digest."""
+
+    step: int
+    agent: str
+    status: StepStatus
+    summary: str
+
+
+class ClarificationContent(BaseModel):
+    """The planner could not route the request — a question for the user."""
+
+    question: str
+
+
+class OrchestratorSummaryStep(BaseModel):
+    step: int
+    agent: str
+    task: str
+    status: StepStatus | Literal["skipped"]
+    summary: str
+
+
+class OrchestratorFinalContent(BaseModel):
+    """Structured per-step summary emitted once at the end of the run."""
+
+    steps: list[OrchestratorSummaryStep]
+
+
+class OrchestratorResponse(BaseModel):
+    """SSE event envelope for the orchestrator pipeline."""
+
+    type: Literal[
+        "pipeline_started",
+        "service_event",
+        "status",
+        "plan",
+        "step_started",
+        "step_event",
+        "step_finished",
+        "clarification",
+        "orchestrator_final",
+        "chunk",
+        "warning",
+        "error",
+    ]
+    content: (
+        PipelineStartedContent
+        | ServiceEvent
+        | OrchestratorStatusResponse
+        | PlanContent
+        | StepStartedContent
+        | StepEventContent
+        | StepFinishedContent
+        | ClarificationContent
+        | OrchestratorFinalContent
+        | DvdTextResponse
+        | WarningContent
+        | SseBaseError
+    )

--- a/src/agents/services/orchestrator_catalog.py
+++ b/src/agents/services/orchestrator_catalog.py
@@ -1,0 +1,130 @@
+"""
+Static catalogue of the gMART agents the orchestrator can route a request to.
+
+Descriptions are written in Russian (the domain language) — they are embedded
+verbatim into the orchestrator planner's system prompt, so the LLM routes user
+requests based on these texts. Keep them accurate and example-rich.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from src.agents.services.service_entities.orchestrator_plan import OrchestratorAgent
+
+if TYPE_CHECKING:
+    from src.agents.common.config.app_config import AgentsAppConfig
+
+
+@dataclass(frozen=True)
+class AgentCatalogEntry:
+    """
+    A single routable agent as the planner sees it.
+    Attributes:
+        key (OrchestratorAgent): Stable agent key used in plan steps.
+        title (str): Human-readable Russian title (used in SSE events and digests).
+        description (str): What the agent does and which requests it fits (Russian).
+        examples (tuple[str, ...]): Example user requests the agent handles.
+        requires_scenario_id (bool): True when the agent cannot run without a
+            scenario selected in Urban API.
+    """
+
+    key: OrchestratorAgent
+    title: str
+    description: str
+    examples: tuple[str, ...]
+    requires_scenario_id: bool
+
+
+AGENT_CATALOG: dict[OrchestratorAgent, AgentCatalogEntry] = {
+    OrchestratorAgent.RESTRICTION: AgentCatalogEntry(
+        key=OrchestratorAgent.RESTRICTION,
+        title="Агент градостроительных ограничений",
+        description=(
+            "Извлекает из запроса градостроительные ограничения для выбранного "
+            "сценария, строит буферные зоны вокруг объектов и формирует слои "
+            "ограничений застройки (GeoJSON). Подходит для запросов про зоны "
+            "ограничений, санитарные/охранные буферы и территории, где нельзя строить."
+        ),
+        examples=(
+            "Построй ограничения застройки от рек и дорог",
+            "Сформируй буферные зоны 100 метров вокруг промышленных объектов",
+        ),
+        requires_scenario_id=True,
+    ),
+    OrchestratorAgent.PROVISION: AgentCatalogEntry(
+        key=OrchestratorAgent.PROVISION,
+        title="Агент обеспеченности сервисами",
+        description=(
+            "Анализирует обеспеченность территории городскими сервисами для "
+            "выбранного сценария: список доступных сервисов, сводка "
+            "дефицита/профицита по каталогу, расчёт текущей обеспеченности или "
+            "эффектов проекта по конкретному сервису. Возвращает слои, таблицы "
+            "и аналитический разбор."
+        ),
+        examples=(
+            "Какая обеспеченность школами?",
+            "Как проект повлияет на обеспеченность детскими садами?",
+            "Дай сводку по обеспеченности сервисами",
+        ),
+        requires_scenario_id=True,
+    ),
+    OrchestratorAgent.DOCUMENTS: AgentCatalogEntry(
+        key=OrchestratorAgent.DOCUMENTS,
+        title="Агент вопросов по нормативной документации",
+        description=(
+            "Отвечает на вопросы по текстам нормативных документов "
+            "градостроительной сферы (RAG-поиск по базе IDU_DVD): требования, "
+            "нормы, определения, формулировки из СП, СанПиН, региональных "
+            "нормативов и т.п."
+        ),
+        examples=(
+            "Какие требования к инсоляции жилых помещений?",
+            "Что говорит СП о ширине пешеходных дорожек?",
+        ),
+        requires_scenario_id=False,
+    ),
+    OrchestratorAgent.NORMS: AgentCatalogEntry(
+        key=OrchestratorAgent.NORMS,
+        title="Агент графа нормативных ограничений",
+        description=(
+            "Отвечает на вопросы о нормативных ограничениях как о связанных "
+            "правилах (граф NormGraph): какие ограничения действуют на объект "
+            "или вид деятельности, их субъекты, значения и конфликты между "
+            "нормами."
+        ),
+        examples=(
+            "Какие нормативные ограничения действуют на строительство школ?",
+            "Есть ли противоречия в нормах о санитарных зонах?",
+        ),
+        requires_scenario_id=False,
+    ),
+}
+
+
+def available_agents(
+    app_config: "AgentsAppConfig",
+    scenario_id: int | None,
+) -> list[AgentCatalogEntry]:
+    """
+    Function filters the catalogue down to the agents that can actually run.
+    Args:
+        app_config (AgentsAppConfig): Application config (optional MCP URLs gate
+            the documents/norms agents).
+        scenario_id (int | None): Scenario ID from the request; agents requiring
+            a scenario are excluded when it is absent.
+    Returns:
+        list[AgentCatalogEntry]: Agents available for the current request.
+    """
+
+    agents: list[AgentCatalogEntry] = []
+    for entry in AGENT_CATALOG.values():
+        if entry.requires_scenario_id and scenario_id is None:
+            continue
+        if entry.key == OrchestratorAgent.DOCUMENTS and not app_config.DVD_MCP_URL:
+            continue
+        if entry.key == OrchestratorAgent.NORMS and not app_config.NORM_GRAPH_MCP_URL:
+            continue
+        agents.append(entry)
+    return agents

--- a/src/agents/services/orchestrator_plan_builder.py
+++ b/src/agents/services/orchestrator_plan_builder.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+
+from loguru import logger
+from pydantic import ValidationError
+
+from src.agents.services.orchestrator_catalog import AgentCatalogEntry
+from src.agents.services.restriction_catalog import strip_json_fence
+from src.agents.services.service_entities.orchestrator_plan import (
+    MAX_PLAN_STEPS,
+    OrchestratorPlan,
+    OrchestratorPlanMode,
+)
+
+
+class OrchestratorPlanBuilder:
+    """
+    LLM planner that maps a user request onto a sequential plan of agent steps.
+
+    Mirrors ``ProvisionPlanBuilder``: a deterministic (temperature 0) chat call
+    with a Russian system prompt embedding the agent catalogue and a JSON
+    skeleton, a self-repair retry loop on invalid JSON, and a canonicalization
+    pass that downgrades plans referencing unavailable agents to a clarification.
+    """
+
+    def __init__(self, llm_client) -> None:
+        self.llm_client = llm_client
+
+    async def build_plan(
+        self,
+        model: str,
+        user_query: str,
+        agents: list[AgentCatalogEntry],
+        history: list[dict] | None = None,
+    ) -> OrchestratorPlan:
+        plan = await self._request_plan(model, user_query, agents, history)
+        plan = self._canonicalize_plan(plan, agents)
+        if (
+            plan.mode == OrchestratorPlanMode.NEEDS_CLARIFICATION
+            and not plan.clarification_question
+        ):
+            plan = plan.model_copy(
+                update={"clarification_question": self._clarification_text(agents)}
+            )
+        logger.info(
+            f"Built orchestration plan: {plan.model_dump_json(ensure_ascii=False)}"
+        )
+        return plan
+
+    def _canonicalize_plan(
+        self, plan: OrchestratorPlan, agents: list[AgentCatalogEntry]
+    ) -> OrchestratorPlan:
+        """Downgrade plans referencing unavailable agents; cap the step count."""
+        if plan.mode != OrchestratorPlanMode.EXECUTE:
+            return plan
+        available_keys = {entry.key for entry in agents}
+        if any(step.agent not in available_keys for step in plan.steps):
+            return OrchestratorPlan(
+                mode=OrchestratorPlanMode.NEEDS_CLARIFICATION,
+                clarification_question=self._clarification_text(agents),
+            )
+        if len(plan.steps) > MAX_PLAN_STEPS:
+            return plan.model_copy(update={"steps": plan.steps[:MAX_PLAN_STEPS]})
+        return plan
+
+    async def _request_plan(
+        self,
+        model: str,
+        user_query: str,
+        agents: list[AgentCatalogEntry],
+        history: list[dict] | None = None,
+        _retries: int = 2,
+    ) -> OrchestratorPlan:
+        messages: list[dict] = [
+            {"role": "system", "content": self._build_prompt(agents)},
+            *(history or []),
+            {"role": "user", "content": user_query},
+        ]
+        for attempt in range(_retries + 1):
+            response = await self.llm_client.chat(
+                model=model,
+                options={"temperature": 0, "num_predict": 768},
+                messages=messages,
+            )
+            content = response["message"]["content"]
+            logger.debug(f"LLM orchestration plan response [{model}]: {content}")
+            try:
+                return OrchestratorPlan.model_validate_json(strip_json_fence(content))
+            except (ValidationError, json.JSONDecodeError) as exc:
+                if attempt < _retries:
+                    logger.warning(
+                        f"LLM returned invalid orchestration plan JSON "
+                        f"(retries left: {_retries - attempt - 1}): {exc}"
+                    )
+                    messages.append({"role": "assistant", "content": content})
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                "Твой предыдущий ответ содержит невалидный JSON. "
+                                "Верни только валидный JSON нужной структуры без markdown и пояснений."
+                            ),
+                        }
+                    )
+                else:
+                    raise ValueError(
+                        "Model returned invalid orchestration plan"
+                    ) from exc
+        raise AssertionError("unreachable")
+
+    @staticmethod
+    def _build_prompt(agents: list[AgentCatalogEntry]) -> str:
+        agents_block = "\n".join(
+            f'- "{entry.key}" — {entry.title}. {entry.description} '
+            f"Примеры запросов: {'; '.join(f'«{example}»' for example in entry.examples)}."
+            for entry in agents
+        )
+        response_structure = {
+            "mode": "execute | needs_clarification",
+            "steps": [
+                {
+                    "agent": "ключ агента из списка доступных",
+                    "task": "самодостаточная формулировка подзадачи на русском",
+                }
+            ],
+            "clarification_question": "вопрос пользователю или null",
+        }
+        return f"""Ты — маршрутизатор запросов пользователя между специализированными агентами \
+платформы градостроительного анализа. Твоя задача — разобрать запрос и составить план \
+из шагов, каждый из которых выполняет один агент.
+
+Доступные агенты:
+{agents_block or '- (нет доступных агентов)'}
+
+Верни только валидный JSON без markdown и пояснений:
+{json.dumps(response_structure, ensure_ascii=False)}
+
+Режимы (mode):
+- "execute" — запрос (или его части) подходит хотя бы одному доступному агенту. \
+Поле steps обязательно и содержит от 1 до {MAX_PLAN_STEPS} шагов.
+- "needs_clarification" — запрос не подходит ни одному доступному агенту, неоднозначен \
+или требует данных, которых нет (например, нужен расчёт по сценарию, а агенты расчёта \
+недоступны без выбранного сценария). Поле steps должно быть пустым, а \
+clarification_question обязателен.
+
+Правила составления шагов:
+- Используй ТОЛЬКО ключи агентов из списка доступных. Не придумывай агентов.
+- Разбивай запрос на несколько шагов только когда для его частей действительно нужны \
+РАЗНЫЕ агенты; иначе делай один шаг. Не дублируй один и тот же агент без необходимости.
+- Каждый task — самодостаточная формулировка подзадачи на русском: агент видит только \
+свой task и не видит исходный запрос и диалог. Переноси в task все нужные детали \
+(названия сервисов, объекты, расстояния, условия).
+- Упорядочивай шаги так, чтобы более поздние могли опираться на результаты более ранних: \
+агенту будет автоматически передана краткая выжимка результатов предыдущих шагов.
+- clarification_question при mode = "needs_clarification": укажи, чего не хватает или \
+что непонятно, перечисли доступных агентов и их возможности и попроси уточнить запрос.
+
+Правила работы с историей диалога:
+- Сообщения переданы в хронологическом порядке, текущий запрос пользователя — последний.
+- Если текущий запрос неполный (например «а теперь для школ», «повтори с буфером 200 метров»), \
+восстанавливай недостающие детали из предыдущих сообщений.
+- При противоречиях между сообщениями приоритет всегда у более поздних."""
+
+    @staticmethod
+    def _clarification_text(agents: list[AgentCatalogEntry]) -> str:
+        if not agents:
+            return (
+                "Сейчас нет доступных агентов для обработки запроса. "
+                "Если нужен расчёт ограничений или обеспеченности, выберите сценарий "
+                "и повторите запрос."
+            )
+        agents_str = "; ".join(f"{entry.title} ({entry.key})" for entry in agents)
+        return (
+            "Не удалось определить, какой агент должен обработать запрос. "
+            f"Доступные агенты: {agents_str}. "
+            "Пожалуйста, уточните, что именно нужно сделать."
+        )

--- a/src/agents/services/orchestrator_service.py
+++ b/src/agents/services/orchestrator_service.py
@@ -1,0 +1,586 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from src.agents.api_clients.chat_storage_client.chat_storage_client import (
+    ChatStorageApiClient,
+)
+from src.agents.api_clients.chat_storage_client.entities import RoleEnum
+from src.agents.api_clients.chat_storage_client.request_models import (
+    TextPartRequest,
+    TextPayload,
+)
+from src.agents.api_clients.urban_api_client.urban_api_client import UrbanApiClient
+from src.agents.common.config.app_config import AgentsAppConfig
+from src.agents.common.exceptions.token_exceptions import PipelineSuspendedError
+from src.agents.services.base_llm_service import BaseLlmService
+from src.agents.services.dvd_rag_service import DvdRagService
+from src.agents.services.normgraph_rag_service import NormGraphRagService
+from src.agents.services.orchestrator_catalog import (
+    AGENT_CATALOG,
+    AgentCatalogEntry,
+    available_agents,
+)
+from src.agents.services.orchestrator_plan_builder import OrchestratorPlanBuilder
+from src.agents.services.pipeline_state import PipelineStateStore, PipelineStatus
+from src.agents.services.provsion_service import ProvisionService
+from src.agents.services.restriction_parser_service import (
+    RestrictionParserService,
+)
+from src.agents.services.service_entities.orchestrator_plan import (
+    OrchestratorAgent,
+    OrchestratorPlan,
+    OrchestratorPlanMode,
+    OrchestratorStep,
+)
+
+if TYPE_CHECKING:
+    from src.agents.mcp_clients.dvd_mcp_client import DvdMcpClient
+    from src.agents.mcp_clients.effects_mcp_client import EffectsMcpClient
+    from src.agents.mcp_clients.idu_mcp_client import IduMcpClient
+    from src.agents.mcp_clients.normgraph_mcp_client import NormGraphMcpClient
+
+# Inner sub-agent event types that are never forwarded to the client: the outer
+# stream announces the step itself (step_started) and owns the chat lifecycle.
+_SUPPRESSED_INNER_EVENTS = {"pipeline_started", "service_event"}
+
+
+class OrchestratorService(BaseLlmService):
+    """
+    Single entry point routing a user request across the gMART agents.
+
+    An LLM planner maps the request onto a sequential plan of 1..3 steps over the
+    restriction / provision / documents / norms agents (or a clarification
+    question when nothing fits). Each step invokes the corresponding pipeline
+    service **in-process** with ``persist_history=False`` and its own
+    ``request_id``; the sub-agent's events are forwarded verbatim inside
+    ``step_event`` envelopes. Between steps only a short text digest of the
+    previous results is passed (no GeoJSON threading in v1).
+
+    The orchestrator owns the ChatStorage lifecycle: it creates the chat, stores
+    the user question and persists one combined assistant message with a text
+    part per step, so follow-up requests in the same chat give the planner the
+    full dialogue context.
+
+    Reconnect (v1): every emitted event is buffered in Redis keyed by the outer
+    ``request_id``; reconnecting with the same ``request_id`` replays the
+    buffered events only — unfinished steps are not resumed.
+    """
+
+    DIGEST_MAX_CHARS = 1500
+
+    def __init__(
+        self,
+        ollama_host: str,
+        chat_storage_client: ChatStorageApiClient,
+        urban_api_client: UrbanApiClient,
+        state_store: PipelineStateStore,
+        restriction_service: RestrictionParserService,
+        provision_service: ProvisionService,
+        dvd_service: DvdRagService,
+        normgraph_service: NormGraphRagService,
+        app_config: AgentsAppConfig,
+    ) -> None:
+        super().__init__(ollama_host, chat_storage_client, urban_api_client)
+        self.state_store = state_store
+        self.restriction_service = restriction_service
+        self.provision_service = provision_service
+        self.dvd_service = dvd_service
+        self.normgraph_service = normgraph_service
+        self.app_config = app_config
+        self.plan_builder = OrchestratorPlanBuilder(self.llm_client)
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def run_orchestration_pipeline(
+        self,
+        idu_mcp_client: "IduMcpClient",
+        effects_mcp_client: "EffectsMcpClient",
+        dvd_mcp_client: "DvdMcpClient | None",
+        normgraph_mcp_client: "NormGraphMcpClient | None",
+        token: str,
+        model: str,
+        temperature: float,
+        user_query: str,
+        scenario_id: int | None = None,
+        chat_id: str | None = None,
+        request_id: str | None = None,
+        persist_history: bool = True,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        is_reconnect = request_id is not None and await self.state_store.exists(
+            request_id
+        )
+        if is_reconnect:
+            logger.info(
+                f"Orchestrator reconnect request_id={request_id}, "
+                "replaying buffered events"
+            )
+            for event in await self.state_store.get_buffered_events(request_id):
+                yield event
+            return
+        request_id = request_id or self.state_store.new_request_id()
+
+        original_chat_id = chat_id
+        yield self._buf(request_id, self._pipeline_started_event(request_id))
+
+        # No chat_id supplied → create a new chat. Chat storage failures must not
+        # break the stream: the pipeline keeps going without persistence.
+        if not chat_id and persist_history:
+            try:
+                chat_id, title = await self.create_chat(
+                    token,
+                    model,
+                    user_query,
+                    additional_instructions=(
+                        "Запрос направлен агенту-оркестратору, распределяющему "
+                        "задачи между агентами платформы."
+                    ),
+                    scenario_id=scenario_id,
+                )
+                yield self._buf(request_id, self._chat_created_event(chat_id, title))
+            except Exception as exc:
+                logger.warning(f"Orchestrator: failed to create chat: {exc}")
+                chat_id = None
+
+        await self.state_store.create(
+            request_id,
+            chat_id=chat_id,
+            user_query=user_query,
+            scenario_id=scenario_id,
+            model=model,
+            temperature=temperature,
+        )
+
+        history: list[dict] = []
+        if original_chat_id:
+            try:
+                chat_info = await self.get_chat_messages(token, original_chat_id)
+                history = self.build_llm_history(
+                    chat_info.messages, current_user_query=user_query
+                )
+            except Exception as exc:
+                logger.warning(f"Orchestrator: failed to fetch chat history: {exc}")
+
+        # A follow-up question in an existing chat is persisted here — create_chat
+        # stores only the first one. Runs after the history fetch so the current
+        # question doesn't also enter the planner context from storage.
+        if persist_history and original_chat_id:
+            try:
+                await self.add_single_message(
+                    token,
+                    original_chat_id,
+                    RoleEnum.USER,
+                    user_query,
+                    scenario_id=scenario_id,
+                )
+            except Exception as exc:
+                logger.warning(f"Orchestrator: failed to persist user question: {exc}")
+
+        # ── Planning ───────────────────────────────────────────────────
+        yield self._buf(
+            request_id,
+            self._status("planning", "Определяю, какие агенты нужны для запроса…"),
+        )
+        agents = available_agents(self.app_config, scenario_id)
+        plan = await self.plan_builder.build_plan(model, user_query, agents, history)
+
+        if plan.mode == OrchestratorPlanMode.NEEDS_CLARIFICATION:
+            question = plan.clarification_question or ""
+            yield self._buf(request_id, self._clarification_event(question))
+            if persist_history:
+                self._schedule_persist_text(token, chat_id, question, scenario_id)
+            await self.state_store.set_status(request_id, PipelineStatus.DONE)
+            return
+
+        # ── Execution ──────────────────────────────────────────────────
+        yield self._buf(request_id, self._plan_event(plan))
+
+        summary_steps: list[dict[str, Any]] = []
+        digests: list[tuple[OrchestratorStep, str]] = []
+        aborted = False
+
+        for step_number, step in enumerate(plan.steps, start=1):
+            if aborted:
+                summary_steps.append(
+                    self._summary_step(step_number, step, "skipped", "")
+                )
+                continue
+
+            effective_query = self._compose_step_query(step, digests)
+            step_request_id = self.state_store.new_request_id()
+            yield self._buf(
+                request_id,
+                self._step_started_event(
+                    step_number, step, step_request_id, effective_query
+                ),
+            )
+
+            status = "completed"
+            collected: dict[str, Any] = {"chunks": {}, "notes": []}
+            try:
+                pipeline = self._build_step_pipeline(
+                    step,
+                    effective_query,
+                    step_request_id,
+                    idu_mcp_client,
+                    effects_mcp_client,
+                    dvd_mcp_client,
+                    normgraph_mcp_client,
+                    token,
+                    model,
+                    temperature,
+                    scenario_id,
+                )
+                async for item in pipeline:
+                    if item.get("type") in _SUPPRESSED_INNER_EVENTS:
+                        continue
+                    self._collect_digest(collected, item)
+                    yield self._buf(
+                        request_id,
+                        self._step_event(step_number, step, item),
+                    )
+                    if item.get("type") == "error":
+                        status = "failed"
+                        break
+                    if item.get("type") == "pipeline_suspended":
+                        status = "suspended"
+                        break
+            except PipelineSuspendedError:
+                status = "suspended"
+            except Exception as exc:
+                logger.opt(exception=exc).error(
+                    f"Orchestrator: step {step_number} ({step.agent}) failed"
+                )
+                status = "failed"
+
+            digest = self._digest_from_collected(collected)
+            yield self._buf(
+                request_id,
+                self._step_finished_event(step_number, step, status, digest),
+            )
+            summary_steps.append(self._summary_step(step_number, step, status, digest))
+            if status == "completed":
+                digests.append((step, digest))
+            else:
+                # Later steps consume earlier digests; running them after a
+                # failure would produce misleading results — abort the plan.
+                aborted = True
+
+        yield self._buf(request_id, self._final_event(summary_steps))
+        await self.state_store.set_status(
+            request_id, PipelineStatus.FAILED if aborted else PipelineStatus.DONE
+        )
+        if persist_history:
+            self._schedule_persist_summary(token, chat_id, summary_steps, scenario_id)
+
+    # ------------------------------------------------------------------
+    # Step dispatch (in-process pipeline invocation)
+    # ------------------------------------------------------------------
+
+    def _build_step_pipeline(
+        self,
+        step: OrchestratorStep,
+        user_query: str,
+        step_request_id: str,
+        idu_mcp_client: "IduMcpClient",
+        effects_mcp_client: "EffectsMcpClient",
+        dvd_mcp_client: "DvdMcpClient | None",
+        normgraph_mcp_client: "NormGraphMcpClient | None",
+        token: str,
+        model: str,
+        temperature: float,
+        scenario_id: int | None,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        if step.agent == OrchestratorAgent.RESTRICTION:
+            if scenario_id is None:
+                raise ValueError("restriction step requires scenario_id")
+            return self.restriction_service.run_restriction_execution_pipline(
+                mcp_client=idu_mcp_client,
+                temperature=temperature,
+                model=model,
+                user_query=user_query,
+                scenario_id=scenario_id,
+                request_id=step_request_id,
+                persist_history=False,
+            )
+        if step.agent == OrchestratorAgent.PROVISION:
+            if scenario_id is None:
+                raise ValueError("provision step requires scenario_id")
+            return self.provision_service.run_provision_pipeline(
+                idu_mcp_client=idu_mcp_client,
+                effects_mcp_client=effects_mcp_client,
+                model=model,
+                temperature=temperature,
+                user_query=user_query,
+                scenario_id=scenario_id,
+                request_id=step_request_id,
+                persist_history=False,
+            )
+        if step.agent == OrchestratorAgent.DOCUMENTS:
+            if dvd_mcp_client is None:
+                raise ValueError("documents step requires DVD_MCP_SERVER")
+            return self.dvd_service.run_document_qa_pipeline(
+                dvd_mcp_client=dvd_mcp_client,
+                token=token,
+                model=model,
+                temperature=temperature,
+                user_query=user_query,
+                scenario_id=scenario_id,
+                request_id=step_request_id,
+                persist_history=False,
+            )
+        if step.agent == OrchestratorAgent.NORMS:
+            if normgraph_mcp_client is None:
+                raise ValueError("norms step requires NORM_GRAPH_MCP_SERVER")
+            return self.normgraph_service.run_norms_qa_pipeline(
+                normgraph_mcp_client=normgraph_mcp_client,
+                token=token,
+                model=model,
+                temperature=temperature,
+                user_query=user_query,
+                scenario_id=scenario_id,
+                request_id=step_request_id,
+                persist_history=False,
+            )
+        raise ValueError(f"Unknown orchestrator agent: {step.agent}")
+
+    # ------------------------------------------------------------------
+    # Text digest between steps
+    # ------------------------------------------------------------------
+
+    def _compose_step_query(
+        self,
+        step: OrchestratorStep,
+        digests: list[tuple[OrchestratorStep, str]],
+    ) -> str:
+        if not digests:
+            return step.task
+        context_lines = "\n".join(
+            f"[Шаг {number}, {self._agent_title(prev.agent)}] {digest}"
+            for number, (prev, digest) in enumerate(digests, start=1)
+            if digest
+        )
+        if not context_lines:
+            return step.task
+        return (
+            f"{step.task}\n\nКонтекст — результаты предыдущих шагов:\n{context_lines}"
+        )
+
+    @staticmethod
+    def _collect_digest(collected: dict[str, Any], item: dict[str, Any]) -> None:
+        content = item.get("content") or {}
+        if not isinstance(content, dict):
+            return
+        if item.get("type") == "chunk":
+            # DVD/norms tag chunks with the draft iteration; only the last
+            # (accepted) draft belongs in the digest, so texts are keyed by it.
+            iteration = int(content.get("iteration") or 0)
+            collected["chunks"].setdefault(iteration, []).append(
+                content.get("text") or ""
+            )
+        elif item.get("type") == "feature_collection" and content.get("name"):
+            collected["notes"].append(f"Построен слой «{content['name']}».")
+        elif item.get("type") == "table" and (
+            content.get("title") or content.get("name")
+        ):
+            title = content.get("title") or content.get("name")
+            collected["notes"].append(f"Сформирована таблица «{title}».")
+
+    def _digest_from_collected(self, collected: dict[str, Any]) -> str:
+        chunks: dict[int, list[str]] = collected["chunks"]
+        text = "".join(chunks[max(chunks)]).strip() if chunks else ""
+        parts = [part for part in (text, " ".join(collected["notes"])) if part]
+        digest = "\n".join(parts)
+        if len(digest) > self.DIGEST_MAX_CHARS:
+            digest = digest[: self.DIGEST_MAX_CHARS - 1].rstrip() + "…"
+        return digest
+
+    # ------------------------------------------------------------------
+    # Chat storage persistence (combined assistant answer)
+    # ------------------------------------------------------------------
+
+    def _schedule_persist_summary(
+        self,
+        token: str,
+        chat_id: str | None,
+        summary_steps: list[dict[str, Any]],
+        scenario_id: int | None,
+    ) -> None:
+        text_blocks = [
+            f"Шаг {step['step']} — {self._agent_title(step['agent'])}: "
+            f"{step['task']}\n\n"
+            + (step["summary"] or f"(шаг не выполнен: {step['status']})")
+            for step in summary_steps
+        ]
+        if not text_blocks:
+            return
+        self._schedule_persist_parts(
+            token,
+            chat_id,
+            [
+                TextPartRequest(kind="text", payload=TextPayload(text=block))
+                for block in text_blocks
+            ],
+            scenario_id,
+        )
+
+    def _schedule_persist_text(
+        self,
+        token: str,
+        chat_id: str | None,
+        text: str,
+        scenario_id: int | None,
+    ) -> None:
+        if not text:
+            return
+        self._schedule_persist_parts(
+            token,
+            chat_id,
+            [TextPartRequest(kind="text", payload=TextPayload(text=text))],
+            scenario_id,
+        )
+
+    def _schedule_persist_parts(
+        self,
+        token: str,
+        chat_id: str | None,
+        parts: list[TextPartRequest],
+        scenario_id: int | None,
+    ) -> None:
+        if not chat_id:
+            return
+        task = asyncio.create_task(
+            self.add_complex_message(
+                token, chat_id, RoleEnum.ASSISTANT, parts, scenario_id=scenario_id
+            )
+        )
+        task.add_done_callback(self._log_persist_result)
+
+    @staticmethod
+    def _log_persist_result(task: asyncio.Task) -> None:
+        try:
+            task.result()
+        except Exception as exc:
+            logger.exception(f"Orchestrator: failed to persist answer: {exc}")
+
+    # ------------------------------------------------------------------
+    # Event helpers
+    # ------------------------------------------------------------------
+
+    def _buf(self, request_id: str, event: dict) -> dict:
+        """Fire-and-forget buffer the event for reconnect replay, then return it."""
+        asyncio.create_task(self.state_store.buffer_event(request_id, event))
+        return event
+
+    @staticmethod
+    def _agent_title(agent: OrchestratorAgent | str) -> str:
+        entry: AgentCatalogEntry | None = AGENT_CATALOG.get(OrchestratorAgent(agent))
+        return entry.title if entry else str(agent)
+
+    @staticmethod
+    def _pipeline_started_event(request_id: str) -> dict:
+        return {"type": "pipeline_started", "content": {"request_id": request_id}}
+
+    @staticmethod
+    def _status(status: str, text: str) -> dict:
+        return {"type": "status", "content": {"status": status, "text": text}}
+
+    def _plan_event(self, plan: OrchestratorPlan) -> dict:
+        return {
+            "type": "plan",
+            "content": {
+                "steps": [
+                    {
+                        "step": number,
+                        "agent": step.agent.value,
+                        "agent_title": self._agent_title(step.agent),
+                        "task": step.task,
+                    }
+                    for number, step in enumerate(plan.steps, start=1)
+                ]
+            },
+        }
+
+    @staticmethod
+    def _step_started_event(
+        step_number: int,
+        step: OrchestratorStep,
+        step_request_id: str,
+        task: str,
+    ) -> dict:
+        return {
+            "type": "step_started",
+            "content": {
+                "step": step_number,
+                "agent": step.agent.value,
+                "step_request_id": step_request_id,
+                "task": task,
+            },
+        }
+
+    @staticmethod
+    def _step_event(
+        step_number: int, step: OrchestratorStep, item: dict[str, Any]
+    ) -> dict:
+        return {
+            "type": "step_event",
+            "content": {
+                "step": step_number,
+                "agent": step.agent.value,
+                "event": item,
+            },
+        }
+
+    @staticmethod
+    def _step_finished_event(
+        step_number: int, step: OrchestratorStep, status: str, summary: str
+    ) -> dict:
+        return {
+            "type": "step_finished",
+            "content": {
+                "step": step_number,
+                "agent": step.agent.value,
+                "status": status,
+                "summary": summary,
+            },
+        }
+
+    @staticmethod
+    def _clarification_event(question: str) -> dict:
+        return {"type": "clarification", "content": {"question": question}}
+
+    @staticmethod
+    def _summary_step(
+        step_number: int, step: OrchestratorStep, status: str, summary: str
+    ) -> dict[str, Any]:
+        return {
+            "step": step_number,
+            "agent": step.agent.value,
+            "task": step.task,
+            "status": status,
+            "summary": summary,
+        }
+
+    @staticmethod
+    def _final_event(summary_steps: list[dict[str, Any]]) -> dict:
+        return {"type": "orchestrator_final", "content": {"steps": summary_steps}}
+
+    @staticmethod
+    def _chat_created_event(chat_id: str, chat_title: str) -> dict:
+        return {
+            "type": "service_event",
+            "content": {
+                "event_type": "storage_event",
+                "event": {
+                    "storage_event_type": "chat_created",
+                    "chat_id": chat_id,
+                    "chat_title": chat_title,
+                },
+            },
+        }

--- a/src/agents/services/service_entities/orchestrator_plan.py
+++ b/src/agents/services/service_entities/orchestrator_plan.py
@@ -1,0 +1,37 @@
+from enum import StrEnum
+
+from pydantic import BaseModel, model_validator
+
+# Upper bound on the number of agent steps in a single orchestration plan.
+MAX_PLAN_STEPS = 3
+
+
+class OrchestratorAgent(StrEnum):
+    RESTRICTION = "restriction"
+    PROVISION = "provision"
+    DOCUMENTS = "documents"
+    NORMS = "norms"
+
+
+class OrchestratorPlanMode(StrEnum):
+    EXECUTE = "execute"
+    NEEDS_CLARIFICATION = "needs_clarification"
+
+
+class OrchestratorStep(BaseModel):
+    agent: OrchestratorAgent
+    task: str
+
+
+class OrchestratorPlan(BaseModel):
+    mode: OrchestratorPlanMode
+    steps: list[OrchestratorStep] = []
+    clarification_question: str | None = None
+
+    @model_validator(mode="after")
+    def _check_consistency(self) -> "OrchestratorPlan":
+        if self.mode == OrchestratorPlanMode.EXECUTE and not self.steps:
+            raise ValueError("execute plan must contain at least one step")
+        if self.mode == OrchestratorPlanMode.NEEDS_CLARIFICATION and self.steps:
+            raise ValueError("needs_clarification plan must not contain steps")
+        return self

--- a/tests/unit/test_orchestrator_catalog.py
+++ b/tests/unit/test_orchestrator_catalog.py
@@ -1,0 +1,48 @@
+"""Unit tests for the orchestrator agent catalogue filtering."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.agents.services.orchestrator_catalog import available_agents
+from src.agents.services.service_entities.orchestrator_plan import OrchestratorAgent
+
+
+def config(dvd: str | None = "http://dvd", norms: str | None = "http://norms"):
+    return SimpleNamespace(DVD_MCP_URL=dvd, NORM_GRAPH_MCP_URL=norms)
+
+
+def keys(agents) -> set[OrchestratorAgent]:
+    return {entry.key for entry in agents}
+
+
+def test_all_agents_available_with_scenario_and_urls():
+    assert keys(available_agents(config(), scenario_id=772)) == {
+        OrchestratorAgent.RESTRICTION,
+        OrchestratorAgent.PROVISION,
+        OrchestratorAgent.DOCUMENTS,
+        OrchestratorAgent.NORMS,
+    }
+
+
+def test_scenario_bound_agents_excluded_without_scenario():
+    assert keys(available_agents(config(), scenario_id=None)) == {
+        OrchestratorAgent.DOCUMENTS,
+        OrchestratorAgent.NORMS,
+    }
+
+
+def test_documents_excluded_without_dvd_url():
+    assert OrchestratorAgent.DOCUMENTS not in keys(
+        available_agents(config(dvd=None), scenario_id=772)
+    )
+
+
+def test_norms_excluded_without_normgraph_url():
+    assert OrchestratorAgent.NORMS not in keys(
+        available_agents(config(norms=None), scenario_id=772)
+    )
+
+
+def test_no_agents_without_scenario_and_urls():
+    assert available_agents(config(dvd=None, norms=None), scenario_id=None) == []

--- a/tests/unit/test_orchestrator_no_history_persistence.py
+++ b/tests/unit/test_orchestrator_no_history_persistence.py
@@ -1,0 +1,86 @@
+"""``persist_history=False`` on the orchestrator must leave no ChatStorage trace
+(mirror of ``test_a2a_no_history_persistence.py`` for the sub-agent pipelines)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.fixture
+def orchestrator(monkeypatch, fake_llm, fake_urban, state_store):
+    monkeypatch.setattr(
+        "src.agents.model_clients.base_client.AsyncOllamaClient",
+        lambda *a, **k: fake_llm,
+    )
+    from src.agents.services.orchestrator_service import OrchestratorService
+
+    app_config = SimpleNamespace(
+        DVD_MCP_URL="http://dvd", NORM_GRAPH_MCP_URL="http://norms"
+    )
+    svc = OrchestratorService(
+        "http://ollama",
+        Mock(),
+        fake_urban,
+        state_store,
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(),
+        app_config,
+    )
+    svc.create_chat = AsyncMock(return_value=("chat-xyz", "Тестовый чат"))
+    svc.get_chat_messages = AsyncMock(return_value=SimpleNamespace(messages=[]))
+    svc.add_single_message = AsyncMock()
+    svc.add_complex_message = AsyncMock()
+    return svc
+
+
+async def _canned_pipeline(*args, **kwargs):
+    yield {"type": "chunk", "content": {"text": "ответ", "done": False}}
+    yield {"type": "chunk", "content": {"text": "", "done": True}}
+
+
+@pytest.mark.asyncio
+async def test_no_chat_storage_calls_without_persistence(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        json.dumps(
+            {
+                "mode": "execute",
+                "steps": [{"agent": "provision", "task": "задача"}],
+                "clarification_question": None,
+            },
+            ensure_ascii=False,
+        )
+    ]
+    orchestrator.provision_service.run_provision_pipeline = (
+        lambda *a, **k: _canned_pipeline()
+    )
+
+    events = [
+        event
+        async for event in orchestrator.run_orchestration_pipeline(
+            idu_mcp_client=Mock(),
+            effects_mcp_client=Mock(),
+            dvd_mcp_client=Mock(),
+            normgraph_mcp_client=Mock(),
+            token="tok",
+            model="m",
+            temperature=0.5,
+            user_query="запрос",
+            scenario_id=772,
+            persist_history=False,
+        )
+    ]
+    await asyncio.sleep(0)  # let any (wrongly) scheduled persistence tasks run
+
+    assert [e["type"] for e in events if e["type"] == "orchestrator_final"]
+    orchestrator.create_chat.assert_not_awaited()
+    orchestrator.add_single_message.assert_not_awaited()
+    orchestrator.add_complex_message.assert_not_awaited()
+    # no chat_created event either
+    assert not [e for e in events if e["type"] == "service_event"]

--- a/tests/unit/test_orchestrator_plan_builder.py
+++ b/tests/unit/test_orchestrator_plan_builder.py
@@ -1,0 +1,135 @@
+"""Unit tests for ``OrchestratorPlanBuilder`` (LLM routing planner)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.agents.services.orchestrator_catalog import AGENT_CATALOG
+from src.agents.services.orchestrator_plan_builder import OrchestratorPlanBuilder
+from src.agents.services.service_entities.orchestrator_plan import (
+    MAX_PLAN_STEPS,
+    OrchestratorAgent,
+    OrchestratorPlanMode,
+)
+from tests.helpers import FakeLlmClient
+
+
+def orchestration_plan_json(
+    steps: list[dict] | None = None,
+    mode: str = "execute",
+    clarification_question: str | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "mode": mode,
+            "steps": steps or [],
+            "clarification_question": clarification_question,
+        },
+        ensure_ascii=False,
+    )
+
+
+ALL_AGENTS = list(AGENT_CATALOG.values())
+
+
+@pytest.fixture
+def fake_llm() -> FakeLlmClient:
+    return FakeLlmClient()
+
+
+@pytest.fixture
+def builder(fake_llm) -> OrchestratorPlanBuilder:
+    return OrchestratorPlanBuilder(fake_llm)
+
+
+@pytest.mark.asyncio
+async def test_valid_single_step_plan(builder, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json(
+            [{"agent": "provision", "task": "Рассчитай обеспеченность школами"}]
+        )
+    ]
+    plan = await builder.build_plan("m", "обеспеченность школами", ALL_AGENTS)
+    assert plan.mode == OrchestratorPlanMode.EXECUTE
+    assert len(plan.steps) == 1
+    assert plan.steps[0].agent == OrchestratorAgent.PROVISION
+    assert plan.steps[0].task == "Рассчитай обеспеченность школами"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_agent_downgrades_to_clarification(builder, fake_llm):
+    """A plan referencing an agent excluded from the catalogue → clarification."""
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "restriction", "task": "Ограничения"}])
+    ]
+    documents_only = [AGENT_CATALOG[OrchestratorAgent.DOCUMENTS]]
+    plan = await builder.build_plan("m", "построй ограничения", documents_only)
+    assert plan.mode == OrchestratorPlanMode.NEEDS_CLARIFICATION
+    assert not plan.steps
+    assert plan.clarification_question
+
+
+@pytest.mark.asyncio
+async def test_steps_truncated_to_max(builder, fake_llm):
+    steps = [
+        {"agent": "provision", "task": f"задача {i}"} for i in range(MAX_PLAN_STEPS + 2)
+    ]
+    fake_llm.json_responses = [orchestration_plan_json(steps)]
+    plan = await builder.build_plan("m", "много задач", ALL_AGENTS)
+    assert len(plan.steps) == MAX_PLAN_STEPS
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_retries_then_succeeds(builder, fake_llm):
+    fake_llm.json_responses = [
+        "это не json",
+        orchestration_plan_json([{"agent": "documents", "task": "вопрос"}]),
+    ]
+    plan = await builder.build_plan("m", "вопрос по нормам", ALL_AGENTS)
+    assert plan.mode == OrchestratorPlanMode.EXECUTE
+    # first call + one repair round-trip
+    assert len(fake_llm.chat_calls) == 2
+    # the repair message asks for valid JSON
+    assert "невалидный JSON" in fake_llm.chat_calls[1].messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_exhausts_retries(builder, fake_llm):
+    fake_llm.json_responses = ["не json", "опять не json", "и снова"]
+    with pytest.raises(ValueError, match="invalid orchestration plan"):
+        await builder.build_plan("m", "вопрос", ALL_AGENTS)
+
+
+@pytest.mark.asyncio
+async def test_clarification_without_question_gets_default(builder, fake_llm):
+    fake_llm.json_responses = [orchestration_plan_json(mode="needs_clarification")]
+    plan = await builder.build_plan("m", "приготовь борщ", ALL_AGENTS)
+    assert plan.mode == OrchestratorPlanMode.NEEDS_CLARIFICATION
+    assert plan.clarification_question
+
+
+@pytest.mark.asyncio
+async def test_history_is_passed_to_the_llm(builder, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "documents", "task": "вопрос"}])
+    ]
+    history = [
+        {"role": "user", "content": "прошлый вопрос"},
+        {"role": "assistant", "content": "прошлый ответ"},
+    ]
+    await builder.build_plan("m", "а теперь уточни", ALL_AGENTS, history=history)
+    messages = fake_llm.chat_calls[0].messages
+    assert messages[0]["role"] == "system"
+    assert messages[1:3] == history
+    assert messages[-1] == {"role": "user", "content": "а теперь уточни"}
+
+
+@pytest.mark.asyncio
+async def test_planner_runs_deterministically(builder, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "norms", "task": "вопрос"}])
+    ]
+    await builder.build_plan("m", "ограничения на школы", ALL_AGENTS)
+    assert fake_llm.chat_calls[0].options["temperature"] == 0

--- a/tests/unit/test_orchestrator_service_events.py
+++ b/tests/unit/test_orchestrator_service_events.py
@@ -1,0 +1,401 @@
+"""Unit tests for ``OrchestratorService`` — event flow, digests, failure policy."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from tests.helpers import events_of_type, types_of
+
+
+def orchestration_plan_json(
+    steps: list[dict] | None = None,
+    mode: str = "execute",
+    clarification_question: str | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "mode": mode,
+            "steps": steps or [],
+            "clarification_question": clarification_question,
+        },
+        ensure_ascii=False,
+    )
+
+
+class FakePipeline:
+    """A canned sub-agent pipeline: records call kwargs, replays events, may raise."""
+
+    def __init__(
+        self, events: list[dict] | None = None, raise_exc: Exception | None = None
+    ) -> None:
+        self.events = events or []
+        self.raise_exc = raise_exc
+        self.calls: list[dict] = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(kwargs)
+        return self._run()
+
+    async def _run(self):
+        for event in self.events:
+            yield event
+        if self.raise_exc is not None:
+            raise self.raise_exc
+
+
+PROVISION_EVENTS = [
+    {"type": "pipeline_started", "content": {"request_id": "inner-prov"}},
+    {"type": "status", "content": {"status": "effects_calculation", "text": "Считаю…"}},
+    {"type": "chunk", "content": {"text": "Обеспеченность школами 82%", "done": False}},
+    {
+        "type": "feature_collection",
+        "content": {"name": "Слой обеспеченности", "feature_collection": {}},
+    },
+    {"type": "chunk", "content": {"text": "", "done": True}},
+]
+
+RESTRICTION_EVENTS = [
+    {"type": "pipeline_started", "content": {"request_id": "inner-restr"}},
+    {"type": "chunk", "content": {"text": "Ограничения построены", "done": False}},
+    {
+        "type": "feature_collection",
+        "content": {"name": "Зоны ограничений", "feature_collection": {}},
+    },
+    {"type": "chunk", "content": {"text": "", "done": True}},
+]
+
+
+@pytest.fixture
+def orchestrator(monkeypatch, fake_llm, fake_urban, state_store):
+    monkeypatch.setattr(
+        "src.agents.model_clients.base_client.AsyncOllamaClient",
+        lambda *a, **k: fake_llm,
+    )
+    from src.agents.services.orchestrator_service import OrchestratorService
+
+    app_config = SimpleNamespace(
+        DVD_MCP_URL="http://dvd", NORM_GRAPH_MCP_URL="http://norms"
+    )
+    svc = OrchestratorService(
+        "http://ollama",
+        Mock(),
+        fake_urban,
+        state_store,
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(),
+        app_config,
+    )
+    svc.create_chat = AsyncMock(return_value=("chat-xyz", "Тестовый чат"))
+    svc.get_chat_messages = AsyncMock(return_value=SimpleNamespace(messages=[]))
+    svc.add_single_message = AsyncMock()
+    svc.add_complex_message = AsyncMock()
+    return svc
+
+
+async def run_pipeline(svc, **overrides) -> list[dict]:
+    kwargs = dict(
+        idu_mcp_client=Mock(),
+        effects_mcp_client=Mock(),
+        dvd_mcp_client=Mock(),
+        normgraph_mcp_client=Mock(),
+        token="tok",
+        model="m",
+        temperature=0.5,
+        user_query="запрос",
+        scenario_id=772,
+    )
+    kwargs.update(overrides)
+    return [event async for event in svc.run_orchestration_pipeline(**kwargs)]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_step_event_order(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json(
+            [{"agent": "provision", "task": "Рассчитай обеспеченность школами"}]
+        )
+    ]
+    pipeline = FakePipeline(PROVISION_EVENTS)
+    orchestrator.provision_service.run_provision_pipeline = pipeline
+
+    events = await run_pipeline(orchestrator)
+
+    assert types_of(events) == [
+        "pipeline_started",
+        "service_event",  # chat_created
+        "status",  # planning
+        "plan",
+        "step_started",
+        "step_event",  # status
+        "step_event",  # chunk
+        "step_event",  # feature_collection
+        "step_event",  # done chunk
+        "step_finished",
+        "orchestrator_final",
+    ]
+    step_events = events_of_type(events, "step_event")
+    assert all(e["content"]["step"] == 1 for e in step_events)
+    assert all(e["content"]["agent"] == "provision" for e in step_events)
+    # the inner pipeline_started is suppressed
+    inner_types = [e["content"]["event"]["type"] for e in step_events]
+    assert "pipeline_started" not in inner_types
+
+    finished = events_of_type(events, "step_finished")[0]["content"]
+    assert finished["status"] == "completed"
+    assert "Обеспеченность школами 82%" in finished["summary"]
+    assert "Слой обеспеченности" in finished["summary"]
+
+    final = events_of_type(events, "orchestrator_final")[0]["content"]
+    assert [s["status"] for s in final["steps"]] == ["completed"]
+
+
+@pytest.mark.asyncio
+async def test_sub_agents_run_without_persistence_and_own_request_ids(
+    orchestrator, fake_llm
+):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "provision", "task": "задача"}])
+    ]
+    pipeline = FakePipeline(PROVISION_EVENTS)
+    orchestrator.provision_service.run_provision_pipeline = pipeline
+
+    events = await run_pipeline(orchestrator)
+
+    outer_request_id = events_of_type(events, "pipeline_started")[0]["content"][
+        "request_id"
+    ]
+    call = pipeline.calls[0]
+    assert call["persist_history"] is False
+    assert call["request_id"] != outer_request_id
+    assert (
+        call["request_id"]
+        == events_of_type(events, "step_started")[0]["content"]["step_request_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_second_step_receives_first_step_digest(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json(
+            [
+                {"agent": "restriction", "task": "Построй ограничения"},
+                {"agent": "provision", "task": "Оцени обеспеченность"},
+            ]
+        )
+    ]
+    restriction = FakePipeline(RESTRICTION_EVENTS)
+    provision = FakePipeline(PROVISION_EVENTS)
+    orchestrator.restriction_service.run_restriction_execution_pipline = restriction
+    orchestrator.provision_service.run_provision_pipeline = provision
+
+    events = await run_pipeline(orchestrator)
+
+    assert restriction.calls[0]["user_query"] == "Построй ограничения"
+    second_query = provision.calls[0]["user_query"]
+    assert second_query.startswith("Оцени обеспеченность")
+    assert "Контекст — результаты предыдущих шагов" in second_query
+    assert "Ограничения построены" in second_query
+    assert "Зоны ограничений" in second_query
+
+    final = events_of_type(events, "orchestrator_final")[0]["content"]
+    assert [s["status"] for s in final["steps"]] == ["completed", "completed"]
+
+
+# ---------------------------------------------------------------------------
+# Clarification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clarification_plan_calls_no_agents(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json(
+            mode="needs_clarification",
+            clarification_question="Уточните, что нужно сделать.",
+        )
+    ]
+    pipeline = FakePipeline(PROVISION_EVENTS)
+    orchestrator.provision_service.run_provision_pipeline = pipeline
+
+    events = await run_pipeline(orchestrator)
+
+    clarifications = events_of_type(events, "clarification")
+    assert len(clarifications) == 1
+    assert clarifications[0]["content"]["question"] == "Уточните, что нужно сделать."
+    assert not events_of_type(events, "plan")
+    assert not events_of_type(events, "step_started")
+    assert not pipeline.calls
+    # the clarification is persisted as the assistant answer
+    await asyncio.sleep(0)
+    assert orchestrator.add_complex_message.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Failure policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_step_aborts_remaining_steps(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json(
+            [
+                {"agent": "restriction", "task": "Построй ограничения"},
+                {"agent": "provision", "task": "Оцени обеспеченность"},
+            ]
+        )
+    ]
+    failing = FakePipeline(
+        [
+            {"type": "pipeline_started", "content": {"request_id": "inner"}},
+            {"type": "error", "content": {"message": "boom", "traceback": "tb"}},
+        ]
+    )
+    provision = FakePipeline(PROVISION_EVENTS)
+    orchestrator.restriction_service.run_restriction_execution_pipline = failing
+    orchestrator.provision_service.run_provision_pipeline = provision
+
+    events = await run_pipeline(orchestrator)
+
+    finished = events_of_type(events, "step_finished")
+    assert len(finished) == 1
+    assert finished[0]["content"]["status"] == "failed"
+    assert not provision.calls
+    final = events_of_type(events, "orchestrator_final")[0]["content"]
+    assert [s["status"] for s in final["steps"]] == ["failed", "skipped"]
+    # the inner error event is forwarded so the client sees the reason
+    inner_types = [
+        e["content"]["event"]["type"] for e in events_of_type(events, "step_event")
+    ]
+    assert "error" in inner_types
+
+
+@pytest.mark.asyncio
+async def test_step_exception_is_contained(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "provision", "task": "задача"}])
+    ]
+    orchestrator.provision_service.run_provision_pipeline = FakePipeline(
+        [{"type": "status", "content": {"status": "service_lookup", "text": "…"}}],
+        raise_exc=RuntimeError("downstream exploded"),
+    )
+
+    events = await run_pipeline(orchestrator)
+
+    finished = events_of_type(events, "step_finished")[0]["content"]
+    assert finished["status"] == "failed"
+    final = events_of_type(events, "orchestrator_final")[0]["content"]
+    assert [s["status"] for s in final["steps"]] == ["failed"]
+
+
+@pytest.mark.asyncio
+async def test_token_expired_forwarded_verbatim(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "provision", "task": "задача"}])
+    ]
+    token_expired = {
+        "type": "token_expired",
+        "content": {"request_id": "inner-id", "message": "Токен истёк"},
+    }
+    orchestrator.provision_service.run_provision_pipeline = FakePipeline(
+        [token_expired, *PROVISION_EVENTS[1:]]
+    )
+
+    events = await run_pipeline(orchestrator)
+
+    forwarded = [
+        e["content"]["event"]
+        for e in events_of_type(events, "step_event")
+        if e["content"]["event"]["type"] == "token_expired"
+    ]
+    assert forwarded == [token_expired]
+
+
+# ---------------------------------------------------------------------------
+# Digest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_digest_keeps_only_last_iteration(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "documents", "task": "вопрос"}])
+    ]
+    orchestrator.dvd_service.run_document_qa_pipeline = FakePipeline(
+        [
+            {
+                "type": "chunk",
+                "content": {"text": "черновик", "done": False, "iteration": 1},
+            },
+            {
+                "type": "chunk",
+                "content": {"text": "итоговый ответ", "done": False, "iteration": 2},
+            },
+            {"type": "chunk", "content": {"text": "", "done": True, "iteration": 2}},
+        ]
+    )
+
+    events = await run_pipeline(orchestrator)
+
+    summary = events_of_type(events, "step_finished")[0]["content"]["summary"]
+    assert summary == "итоговый ответ"
+
+
+@pytest.mark.asyncio
+async def test_digest_is_capped(orchestrator, fake_llm):
+    fake_llm.json_responses = [
+        orchestration_plan_json([{"agent": "provision", "task": "задача"}])
+    ]
+    orchestrator.provision_service.run_provision_pipeline = FakePipeline(
+        [{"type": "chunk", "content": {"text": "х" * 5000, "done": False}}]
+    )
+
+    events = await run_pipeline(orchestrator)
+
+    summary = events_of_type(events, "step_finished")[0]["content"]["summary"]
+    assert len(summary) <= orchestrator.DIGEST_MAX_CHARS
+    assert summary.endswith("…")
+
+
+# ---------------------------------------------------------------------------
+# Reconnect (v1: replay-only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconnect_replays_buffered_events_only(
+    orchestrator, fake_llm, state_store
+):
+    request_id = state_store.new_request_id()
+    await state_store.create(
+        request_id,
+        chat_id="chat-xyz",
+        user_query="запрос",
+        scenario_id=772,
+        model="m",
+        temperature=0.5,
+    )
+    buffered = [
+        {"type": "pipeline_started", "content": {"request_id": request_id}},
+        {"type": "status", "content": {"status": "planning", "text": "…"}},
+    ]
+    for event in buffered:
+        await state_store.buffer_event(request_id, event)
+
+    events = await run_pipeline(orchestrator, request_id=request_id)
+
+    assert events == buffered
+    assert not fake_llm.chat_calls  # the planner is not re-run
+    orchestrator.create_chat.assert_not_awaited()


### PR DESCRIPTION
…ng requests across all agents

- LLM planner builds a sequential plan of 1..3 steps over the restriction/provision/documents/norms agents (or a clarification question when nothing fits)
- GET /orchestrator/route/stream (SSE): plan, step_started, forwarded step_event envelopes, step_finished digests, orchestrator_final summary
- sub-pipelines run in-process with persist_history=False and own request_ids (token refresh via existing /pipelines/{id}/token keeps working)
- orchestrator owns the ChatStorage lifecycle; only a text digest is passed between steps
- unit tests for planner, catalog filtering, event flow, failure policy and persistence