### PR TITLE
v0.14.1

### DIFF
--- a/src/agents/api_clients/chat_storage_client/chat_storage_client.py
+++ b/src/agents/api_clients/chat_storage_client/chat_storage_client.py
@@ -71,7 +71,7 @@ class ChatStorageApiClient:
         chat = await self.json_handler.get(
             endpoint=f"/api/v1/chat_history/{chat_id}", auth_token=token
         )
-        return ChatHistory(**chat)
+        return ChatHistory.from_response(chat)
 
     async def create_chat(
         self,

--- a/src/agents/api_clients/chat_storage_client/responses.py
+++ b/src/agents/api_clients/chat_storage_client/responses.py
@@ -2,7 +2,7 @@
 Module for converting data from ChatStorage service to python objects.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 from src.agents.api_clients.chat_storage_client.entities import (
     MessageUploadType,
@@ -48,6 +48,7 @@ class ChatHistory:
         updated_at (str): Chat last update date-time.
         messages (list[dict]): Chat messages history.
         scenario_id (int | None): Scenario ID from Urban API to which chat. Default to None.
+        project_id (str | int | None): Project ID from Urban API to which chat. Default to None.
         metadata (dict | None): Chat metadata.
     """
 
@@ -57,4 +58,21 @@ class ChatHistory:
     updated_at: str
     messages: list[dict]
     scenario_id: str | None = None
+    project_id: str | int | None = None
     metadata: dict | None = None
+
+    @classmethod
+    def from_response(cls, data: dict) -> "ChatHistory":
+        """
+        Build a ChatHistory from a raw ChatStorage response, ignoring unknown keys.
+
+        ChatStorage may extend its response with new fields (as it did with
+        ``project_id``) — new keys must not break history parsing on this side.
+        Args:
+            data (dict): Raw chat history response.
+        Returns:
+            ChatHistory: ChatHistory dataclass instance.
+        """
+
+        known = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in data.items() if key in known})

--- a/src/agents/mcp_clients/normgraph_mcp_client.py
+++ b/src/agents/mcp_clients/normgraph_mcp_client.py
@@ -182,27 +182,37 @@ class NormGraphMcpClient(BaseMcpClient):
             if value is not None and value != []
         }
 
-    @staticmethod
-    def _to_dict(obj: Any) -> Any:
+    @classmethod
+    def _to_dict(cls, obj: Any) -> Any:
         """
-        Best-effort conversion of an MCP-returned object into a plain dict.
+        Best-effort recursive conversion of an MCP-returned object into plain data.
 
         FastMCP rehydrates a tool's structured output (via ``result.data``) into synthetic
         types built from its output schema, which are neither a ``dict`` nor a pydantic-v2
         model with ``model_dump``. Try the known converters in order and fall back to
-        attribute inspection so any of those shapes normalizes cleanly.
+        attribute inspection. The conversion is recursive: nested synthetic objects
+        (e.g. ``provenance``/``value`` inside a search hit) must also become dicts —
+        downstream consumers (NormGraphContextBuilder) treat the result as plain JSON.
         """
-        if obj is None or isinstance(obj, dict):
+        if obj is None or isinstance(obj, (str, int, float, bool)):
             return obj
+        if isinstance(obj, dict):
+            return {key: cls._to_dict(value) for key, value in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [cls._to_dict(item) for item in obj]
         for attr in ("model_dump", "dict", "_asdict"):  # pydantic v2 / v1 / namedtuple
             converter = getattr(obj, attr, None)
             if callable(converter):
                 try:
-                    return converter()
+                    return cls._to_dict(converter())
                 except TypeError:
                     continue
         if hasattr(obj, "__dict__"):
-            return {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+            return {
+                key: cls._to_dict(value)
+                for key, value in vars(obj).items()
+                if not key.startswith("_")
+            }
         return obj
 
     @classmethod

--- a/tests/unit/test_chat_storage_responses.py
+++ b/tests/unit/test_chat_storage_responses.py
@@ -1,0 +1,33 @@
+"""Parsing ChatStorage responses — unknown/new fields must not break history loading."""
+
+from __future__ import annotations
+
+from src.agents.api_clients.chat_storage_client.responses import ChatHistory
+
+_BASE = {
+    "chat_id": "c1",
+    "title": "Тестовый чат",
+    "created_at": "2026-07-14T00:00:00Z",
+    "updated_at": "2026-07-14T00:00:00Z",
+    "messages": [],
+}
+
+
+def test_parses_known_fields():
+    history = ChatHistory.from_response({**_BASE, "scenario_id": "772"})
+    assert history.chat_id == "c1"
+    assert history.scenario_id == "772"
+    assert history.project_id is None
+
+
+def test_parses_project_id():
+    history = ChatHistory.from_response({**_BASE, "project_id": 5})
+    assert history.project_id == 5
+
+
+def test_ignores_unknown_fields():
+    history = ChatHistory.from_response(
+        {**_BASE, "project_id": None, "brand_new_field": {"x": 1}}
+    )
+    assert history.title == "Тестовый чат"
+    assert not hasattr(history, "brand_new_field")

--- a/tests/unit/test_normgraph_mcp_client.py
+++ b/tests/unit/test_normgraph_mcp_client.py
@@ -1,0 +1,57 @@
+"""Normalization of NormGraph MCP results — FastMCP synthetic objects must become plain JSON.
+
+FastMCP rehydrates structured tool output into synthetic types built from the output schema
+(``Root`` objects without ``model_dump``); nested fields like ``provenance`` and ``value``
+must be converted to dicts too, or the context builder crashes on ``provenance.get(...)``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.agents.mcp_clients.normgraph_mcp_client import NormGraphMcpClient
+
+
+def _synthetic_hit():
+    """Mimic a FastMCP synthetic object: attribute access only, no model_dump/dict."""
+    return SimpleNamespace(
+        id="382bfe03",
+        subject="[не указано]",
+        object="строительство",
+        kind="запрет_размещения",
+        value=SimpleNamespace(operator=">=", number=3.75, unit="м", condition=None),
+        provenance=SimpleNamespace(
+            doc_id="0e864faf",
+            name="СП 30-102-99",
+            version="1999",
+            tags=["застройка"],
+        ),
+    )
+
+
+class TestToDict:
+    def test_converts_nested_objects_recursively(self):
+        hit = NormGraphMcpClient._to_dict(_synthetic_hit())
+        assert isinstance(hit, dict)
+        assert isinstance(hit["provenance"], dict)
+        assert hit["provenance"]["name"] == "СП 30-102-99"
+        assert isinstance(hit["value"], dict)
+        assert hit["value"]["number"] == 3.75
+
+    def test_converts_lists_and_keeps_scalars(self):
+        converted = NormGraphMcpClient._to_dict(
+            {"hits": [_synthetic_hit()], "count": 1, "note": None}
+        )
+        assert converted["count"] == 1
+        assert converted["note"] is None
+        assert isinstance(converted["hits"][0]["provenance"], dict)
+        assert converted["hits"][0]["provenance"]["tags"] == ["застройка"]
+
+    def test_normalize_search_produces_plain_hits(self):
+        result = SimpleNamespace(
+            count=1, hits=[_synthetic_hit()], neighbors=[], dvd_fallback=[]
+        )
+        normalized = NormGraphMcpClient._normalize_search(result)
+        assert normalized["count"] == 1
+        provenance = normalized["hits"][0]["provenance"]
+        assert provenance.get("name") == "СП 30-102-99"


### PR DESCRIPTION
- feat/auth-helper-login (#117)
- feat/auth-helper-login (#121)
- fix(chat_storage): tolerate new ChatStorage response fields (#119)
- fix(norms_rag): recursively normalize NormGraph MCP results (#120)